### PR TITLE
fix a bug  belongs to bloomfilter's command bfInsert

### DIFF
--- a/redisbloom/client.py
+++ b/redisbloom/client.py
@@ -268,10 +268,10 @@ class Client(Redis): #changed from StrictRedis
         params = [key]
         self.appendCapacity(params, capacity)
         self.appendError(params, error)
-        self.appendNoCreate(params, noCreate)
-        self.appendItems(params, items)
         self.appendExpansion(params, expansion)
+        self.appendNoCreate(params, noCreate)
         self.appendNoScale(params, noScale)
+        self.appendItems(params, items)
 
         return self.execute_command(self.BF_INSERT, *params)
 


### PR DESCRIPTION
fix a bug  of bfInsert  command    
   items = [1, 2, 3, 5, 6, 4]
   arrs = r.bfInsert('bfin1', items, 100, 1e-4, None, 2, None)
when we use  this code  it  returns  the  array  [1,1,1,1,1,1,1,0]   ；because  when it run，it runs  the command is “BF.INSERT bfin1 CAPPCITY 100 ERROR 0.0001 ITEMS  1 2 3 4 5 6 EXPANSION 2”  the last  two elementaries  are keys  which are inserted into bloomfilter  and not work for expansion 。  the correct work command is “ BF.INSERT bfin1 CAPPCITY 100 ERROR 0.0001  EXPANSION 2  ITEMS  1 2 3 4 5 6” ，in that case ，the items must be at the end of params。