### PR TITLE
Add TOPK.LIST WITHCOUNT param

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ rb.topkAdd('topk', 'A', 'B', 'C', 'D', 'E', 'A', 'A', 'B',
                    'C', 'G', 'D', 'B', 'D', 'A', 'E', 'E')
 rb.topkQuery('topk', 'A', 'B', 'C', 'D')    # returns [1, 1, 0, 1]
 rb.topkCount('topk', 'A', 'B', 'C', 'D')    # returns [4, 3, 2, 3]
-rb.topkList('topk')                         # returns ['D', 'A', 'B']
+rb.topkList('topk')                         # returns ['A', 'B', 'E']
 rb.topkListWithCount('topk')                # returns ['A', 4, 'B', 3, 'E', 3]
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ rb.topkAdd('topk', 'A', 'B', 'C', 'D', 'E', 'A', 'A', 'B',
 rb.topkQuery('topk', 'A', 'B', 'C', 'D')    # returns [1, 1, 0, 1]
 rb.topkCount('topk', 'A', 'B', 'C', 'D')    # returns [4, 3, 2, 3]
 rb.topkList('topk')                         # returns ['D', 'A', 'B']
+rb.topkListWithCount('topk')                # returns ['A', 4, 'B', 3, 'E', 3]
 ```
 
 ### API

--- a/redisbloom/client.py
+++ b/redisbloom/client.py
@@ -210,7 +210,6 @@ class Client(Redis):  # changed from StrictRedis
             #self.TOPK_QUERY: spaceHolder,
             #self.TOPK_COUNT: spaceHolder,
             self.TOPK_LIST: parseToList,
-            self.TOPK_LIST: parseToList,
             self.TOPK_INFO: TopKInfo,
 
             self.TDIGEST_CREATE: bool_ok,

--- a/redisbloom/client.py
+++ b/redisbloom/client.py
@@ -98,7 +98,9 @@ def spaceHolder(response):
 def parseToList(response):
     res = []
     for item in response:
-        if item is not None:
+        if isinstance(item, int):
+            res.append(item)
+        elif item is not None:
             res.append(nativestr(item))
         else:
             res.append(None)
@@ -207,6 +209,7 @@ class Client(Redis):  # changed from StrictRedis
             self.TOPK_ADD: parseToList,
             #self.TOPK_QUERY: spaceHolder,
             #self.TOPK_COUNT: spaceHolder,
+            self.TOPK_LIST: parseToList,
             self.TOPK_LIST: parseToList,
             self.TOPK_INFO: TopKInfo,
 
@@ -596,6 +599,13 @@ class Client(Redis):  # changed from StrictRedis
         """
 
         return self.execute_command(self.TOPK_LIST, key)
+
+    def topkListWithCount(self, key):
+        """
+        Return full list of items with probabilistic count in Top-K list of ``key```.
+        """
+
+        return self.execute_command(self.TOPK_LIST, key, 'WITHCOUNT')
 
     def topkInfo(self, key):
         """

--- a/test_commands.py
+++ b/test_commands.py
@@ -187,11 +187,11 @@ class TestRedisBloom(TestCase):
     def testTopK(self):
         # test list with empty buckets
         self.assertTrue(rb.topkReserve('topk', 3, 50, 4, 0.9))
-        self.assertEqual([None, None, None, None, None, None, None, None,
-                          None, None, None, None, 'C', None, None, None, None],
+        self.assertEqual([None, None, None, 'A', 'C', 'D', None, None, 'E',
+                          None, 'B', 'C', None, None, None, 'D', None],
                           rb.topkAdd('topk', 'A', 'B', 'C', 'D', 'E', 'A', 'A', 'B', 'C',
                                      'G', 'D', 'B', 'D', 'A', 'E', 'E', 1))
-        self.assertEqual([1, 1, 0, 1, 0, 0, 0],
+        self.assertEqual([1, 1, 0, 0, 1, 0, 0],
                           rb.topkQuery('topk', 'A', 'B', 'C', 'D', 'E', 'F', 'G'))
         self.assertEqual([4, 3, 2, 3, 3, 0, 1],
                           rb.topkCount('topk', 'A', 'B', 'C', 'D', 'E', 'F', 'G'))
@@ -200,7 +200,8 @@ class TestRedisBloom(TestCase):
         self.assertTrue(rb.topkReserve('topklist', 3, 50, 3, 0.9))
         self.assertTrue(rb.topkAdd('topklist', 'A', 'B', 'C', 'D', 'E','A', 'A', 'B', 'C',
                                    'G', 'D', 'B', 'D', 'A', 'E', 'E'))
-        self.assertEqual(['A', 'D', 'B'], rb.topkList('topklist'))
+        self.assertEqual(['A', 'B', 'E'], rb.topkList('topklist'))
+        self.assertEqual(['A', 4, 'B', 3, 'E', 3], rb.topkListWithCount('topklist'))
         info = rb.topkInfo('topklist')
         self.assertEqual(3, info.k)
         self.assertEqual(50, info.width)


### PR DESCRIPTION
Add `topkListWithCount` to the API.
It is similar to `topkList` but the reply includes the score for each result.
```
['A', 'B', 'E'] -> ['A', 4, 'B', 3, 'E', 3]
```