### PR TITLE
pyproject.toml to rename project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "redisbloom-py"
+name = "redisbloom"
 version = "0.4.1"
 description = "RedisBloom Python Client"
 authors = ["Redis <oss@redis.com>"]


### PR DESCRIPTION
The poetry project needs to be redisbloom, not redisbloom-py, fixing my own bug