### PR TITLE
Add appendCompression to tDigestCreate

### DIFF
--- a/redisbloom/client.py
+++ b/redisbloom/client.py
@@ -283,6 +283,11 @@ class Client(Redis):  # changed from StrictRedis
         if bucket_size is not None:
             params.extend(['BUCKETSIZE', bucket_size])
 
+    @staticmethod
+    def appendCompression(params, compression):
+        if compression is not None:
+            params.extend(['COMPRESSION', compression])
+
 ################## Bloom Filter Functions ######################
     def bfCreate(self, key, errorRate, capacity, expansion=None, noScale=None):
         """
@@ -615,11 +620,12 @@ class Client(Redis):  # changed from StrictRedis
 
 ################## T-Digest Functions ######################
 
-    def tdigestCreate(self, key, compression):
+    def tdigestCreate(self, key, compression=None):
         """"
         Allocate the memory and initialize the t-digest.
         """
-        params = [key, compression]
+        params = [key]
+        self.appendCompression(params, compression)
 
         return self.execute_command(self.TDIGEST_CREATE, *params)
 

--- a/test_commands.py
+++ b/test_commands.py
@@ -248,15 +248,15 @@ class TestRedisBloom(TestCase):
         # assert min min/max have same result as quantile 0 and 1
         self.assertEqual(
             float(rb.tdigestMax('tDigest')),
-            float(rb.tdigestQuantile('tDigest', 1.0)),
+            float(rb.tdigestQuantile('tDigest', 1.0)[0]),
         )
         self.assertEqual(
             float(rb.tdigestMin('tDigest')),
-            float(rb.tdigestQuantile('tDigest', 0.0)),
+            float(rb.tdigestQuantile('tDigest', 0.0)[0]),
         )
 
-        self.assertAlmostEqual(1.0, float(rb.tdigestQuantile('tDigest', 0.01)), 2)
-        self.assertAlmostEqual(99.0, float(rb.tdigestQuantile('tDigest', 0.99)), 2)
+        self.assertAlmostEqual(1.0, float(rb.tdigestQuantile('tDigest', 0.01)[0]), 2)
+        self.assertAlmostEqual(99.0, float(rb.tdigestQuantile('tDigest', 0.99)[0]), 2)
 
     def testTDigestCdf(self):
         self.assertTrue(rb.tdigestCreate('tDigest', 100))


### PR DESCRIPTION
Support for adding the `COMPRESSION` keyword to `TDIGEST.CREATE`.
RedisBloom/RedisBloom#520